### PR TITLE
Add Gray Matter theme

### DIFF
--- a/Themes/Gray Matter (Dark).theme.json
+++ b/Themes/Gray Matter (Dark).theme.json
@@ -1,0 +1,113 @@
+{
+    "name": "Writer",
+    "style": "Dark",
+    "author": [
+        {
+            "name": "Philip Belesky",
+            "url": "http://philipbelesky.com/"
+        },
+    ],
+    "version": "0.9",
+    "editor": {
+        "backgroundColor": "#1A191A",
+        "caretColor": "#29BEEA",
+        "selection": {
+            "backgroundColor": "#373737",
+            "unfocusedBackgroundColor": "#d2d9e1"
+        },
+        "highlight": {
+            "backgroundColor": "#373737",
+            "unfocusedBackgroundColor": "#ececec"
+        }
+    },
+    "savedSearchesSidebar": {
+        "color": "#BEBEBE",
+        "backgroundColor": "#222122",
+        "highlightedBackgroundColor": "#373737",
+        "border": false,
+        "iconColors": {
+            "default": "#616161"
+        }
+    },
+    "resultsList": {
+        "color": "#BEBEBE",
+        "backgroundColor": "#222122",
+        "alternateBackgroundColor": "#222122",
+        "selection": {
+            "color": "#000",
+            "backgroundColor": "#373737",
+            "unfocusedColor": "#000",
+            "unfocusedBackgroundColor": "#222122"
+        },
+        "border": "#222122",
+    },
+    "styles": {
+        "base": {
+            "color": "#BEBEBE"
+        },
+        "h1": {
+            "font": { "style": "bold" }
+        },
+        "h2": {
+            "font": { "style": "bold" }
+        },
+        "h3": {
+            "font": { "style": "bold" }
+        },
+        "h4": {
+            "font": { "style": "bold" }
+        },
+        "h5": {
+            "font": { "style": "bold" }
+        },
+        "h6": {
+            "font": { "style": "bold" }
+        },
+        "horizontalRule": {
+            "color": "#616161",
+            "syntax": { "color" : "#616161" }
+        },
+        "codeBlock": {
+            "color": "#BEBEBE",
+            "backgroundColor": "#222122",
+        },
+        "inlineCode": {
+            "color": "#BEBEBE",
+            "backgroundColor": "#222122",
+        },
+        "blockquote": {
+            "syntax": { "color" : "#616161" }
+        },
+        "list": {
+            "syntax": { "color" : "#616161" }
+        },
+        "emphasis": {
+            "font": { "style": "italic" },
+            "syntax": { "color" : "#616161" }
+        },
+        "strong": {
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" }
+        },
+        "image": {
+            "color": "#BEBEBE",
+            "syntax": { "color" : "#616161" }
+        },
+        "footnote": {
+            "color": "#616161",
+            "syntax": { "color" : "#616161" }
+        },
+        "link": {
+            "color": "#BEBEBE",
+            "syntax": { "color" : "#616161" }
+        },
+        "referenceDefinition": {
+            "color": "#BEBEBE",
+            "syntax": { "color" : "#616161" }
+        },
+        "comment": {
+            "color": "#616161",
+            "font": { "style": "regular" }
+        }
+    }
+}

--- a/Themes/Gray Matter (Dark).theme.json
+++ b/Themes/Gray Matter (Dark).theme.json
@@ -4,7 +4,8 @@
     "author": [
         {
             "name": "Philip Belesky",
-            "url": "http://philipbelesky.com/"
+            "url": "http://philipbelesky.com/",
+            "basedOn": "https://github.com/philipbelesky/gray-matter"
         },
     ],
     "version": "0.9",
@@ -32,49 +33,42 @@
     "resultsList": {
         "color": "#BEBEBE",
         "backgroundColor": "#222122",
-        "alternateBackgroundColor": "#222122",
+        "alternateBackgroundColor": "#1A191A",
         "selection": {
             "color": "#000",
-            "backgroundColor": "#373737",
             "unfocusedColor": "#000",
-            "unfocusedBackgroundColor": "#222122"
+            "backgroundColor": "#373737",
+            "unfocusedBackgroundColor": "#373737"
         },
         "border": "#222122",
     },
     "styles": {
         "base": {
             "color": "#BEBEBE",
-            "indent": {"characters": 7},
         },
         "h1": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 5},
         },
         "h2": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 4},
         },
         "h3": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 3},
         },
         "h4": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 2},
         },
         "h5": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 1},
         },
         "h6": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 0},
         },
         "horizontalRule": {
             "color": "#616161",
@@ -90,7 +84,6 @@
         },
         "blockquote": {
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 5},
         },
         "list": {
             "syntax": { "color" : "#616161" },
@@ -106,7 +99,6 @@
         "image": {
             "color": "#BEBEBE",
             "syntax": { "color" : "#616161" },
-            "indent": {"characters": 5},
         },
         "footnote": {
             "color": "#616161",

--- a/Themes/Gray Matter (Dark).theme.json
+++ b/Themes/Gray Matter (Dark).theme.json
@@ -43,25 +43,38 @@
     },
     "styles": {
         "base": {
-            "color": "#BEBEBE"
+            "color": "#BEBEBE",
+            "indent": {"characters": 7},
         },
         "h1": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 5},
         },
         "h2": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 4},
         },
         "h3": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 3},
         },
         "h4": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 2},
         },
         "h5": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 1},
         },
         "h6": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 0},
         },
         "horizontalRule": {
             "color": "#616161",
@@ -76,10 +89,11 @@
             "backgroundColor": "#222122",
         },
         "blockquote": {
-            "syntax": { "color" : "#616161" }
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 5},
         },
         "list": {
-            "syntax": { "color" : "#616161" }
+            "syntax": { "color" : "#616161" },
         },
         "emphasis": {
             "font": { "style": "italic" },
@@ -91,7 +105,8 @@
         },
         "image": {
             "color": "#BEBEBE",
-            "syntax": { "color" : "#616161" }
+            "syntax": { "color" : "#616161" },
+            "indent": {"characters": 5},
         },
         "footnote": {
             "color": "#616161",

--- a/Themes/Gray Matter (Light).theme.json
+++ b/Themes/Gray Matter (Light).theme.json
@@ -4,7 +4,8 @@
     "author": [
         {
             "name": "Philip Belesky",
-            "url": "http://philipbelesky.com/"
+            "url": "http://philipbelesky.com/",
+            "basedOn": "https://github.com/philipbelesky/gray-matter"
         },
     ],
     "version": "0.9",
@@ -32,49 +33,42 @@
     "resultsList": {
         "color": "#3C3C3C",
         "backgroundColor": "#EDEDED",
-        "alternateBackgroundColor": "#EDEDED",
+        "alternateBackgroundColor": "#F5F5F5",
         "selection": {
             "color": "#000",
-            "backgroundColor": "#C3E8F3",
             "unfocusedColor": "#000",
-            "unfocusedBackgroundColor": "#EDEDED"
+            "backgroundColor": "#C3E8F3",
+            "unfocusedBackgroundColor": "#C3E8F3"
         },
         "border": "#EDEDED",
     },
     "styles": {
         "base": {
             "color": "#3C3C3C",
-            "indent": {"characters": 7},
         },
         "h1": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 5},
         },
         "h2": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 4},
         },
         "h3": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 3},
         },
         "h4": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 2},
         },
         "h5": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 1},
         },
         "h6": {
             "font": { "style": "bold" },
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 0},
         },
         "horizontalRule": {
             "color": "#B9B9B9",
@@ -90,7 +84,6 @@
         },
         "blockquote": {
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 5},
         },
         "list": {
             "syntax": { "color" : "#B9B9B9" },
@@ -106,7 +99,6 @@
         "image": {
             "color": "#3C3C3C",
             "syntax": { "color" : "#B9B9B9" },
-            "indent": {"characters": 5},
         },
         "footnote": {
             "color": "#B9B9B9",

--- a/Themes/Gray Matter (Light).theme.json
+++ b/Themes/Gray Matter (Light).theme.json
@@ -1,0 +1,113 @@
+{
+    "name": "Writer",
+    "style": "Light",
+    "author": [
+        {
+            "name": "Philip Belesky",
+            "url": "http://philipbelesky.com/"
+        },
+    ],
+    "version": "0.9",
+    "editor": {
+        "backgroundColor": "#F5F5F5",
+        "caretColor": "#29BEEA",
+        "selection": {
+            "backgroundColor": "#C3E8F3",
+            "unfocusedBackgroundColor": "#d2d9e1"
+        },
+        "highlight": {
+            "backgroundColor": "#C3E8F3",
+            "unfocusedBackgroundColor": "#ececec"
+        }
+    },
+    "savedSearchesSidebar": {
+        "color": "#3C3C3C",
+        "backgroundColor": "#EDEDED",
+        "highlightedBackgroundColor": "#C3E8F3",
+        "border": false,
+        "iconColors": {
+            "default": "#B9B9B9"
+        }
+    },
+    "resultsList": {
+        "color": "#3C3C3C",
+        "backgroundColor": "#EDEDED",
+        "alternateBackgroundColor": "#EDEDED",
+        "selection": {
+            "color": "#000",
+            "backgroundColor": "#C3E8F3",
+            "unfocusedColor": "#000",
+            "unfocusedBackgroundColor": "#EDEDED"
+        },
+        "border": "#EDEDED",
+    },
+    "styles": {
+        "base": {
+            "color": "#3C3C3C"
+        },
+        "h1": {
+            "font": { "style": "bold" }
+        },
+        "h2": {
+            "font": { "style": "bold" }
+        },
+        "h3": {
+            "font": { "style": "bold" }
+        },
+        "h4": {
+            "font": { "style": "bold" }
+        },
+        "h5": {
+            "font": { "style": "bold" }
+        },
+        "h6": {
+            "font": { "style": "bold" }
+        },
+        "horizontalRule": {
+            "color": "#B9B9B9",
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "codeBlock": {
+            "color": "#3C3C3C",
+            "backgroundColor": "#EDEDED",
+        },
+        "inlineCode": {
+            "color": "#3C3C3C",
+            "backgroundColor": "#EDEDED",
+        },
+        "blockquote": {
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "list": {
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "emphasis": {
+            "font": { "style": "italic" },
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "strong": {
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "image": {
+            "color": "#3C3C3C",
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "footnote": {
+            "color": "#B9B9B9",
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "link": {
+            "color": "#3C3C3C",
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "referenceDefinition": {
+            "color": "#3C3C3C",
+            "syntax": { "color" : "#B9B9B9" }
+        },
+        "comment": {
+            "color": "#B9B9B9",
+            "font": { "style": "regular" }
+        }
+    }
+}

--- a/Themes/Gray Matter (Light).theme.json
+++ b/Themes/Gray Matter (Light).theme.json
@@ -43,25 +43,38 @@
     },
     "styles": {
         "base": {
-            "color": "#3C3C3C"
+            "color": "#3C3C3C",
+            "indent": {"characters": 7},
         },
         "h1": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 5},
         },
         "h2": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 4},
         },
         "h3": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 3},
         },
         "h4": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 2},
         },
         "h5": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 1},
         },
         "h6": {
-            "font": { "style": "bold" }
+            "font": { "style": "bold" },
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 0},
         },
         "horizontalRule": {
             "color": "#B9B9B9",
@@ -76,10 +89,11 @@
             "backgroundColor": "#EDEDED",
         },
         "blockquote": {
-            "syntax": { "color" : "#B9B9B9" }
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 5},
         },
         "list": {
-            "syntax": { "color" : "#B9B9B9" }
+            "syntax": { "color" : "#B9B9B9" },
         },
         "emphasis": {
             "font": { "style": "italic" },
@@ -91,7 +105,8 @@
         },
         "image": {
             "color": "#3C3C3C",
-            "syntax": { "color" : "#B9B9B9" }
+            "syntax": { "color" : "#B9B9B9" },
+            "indent": {"characters": 5},
         },
         "footnote": {
             "color": "#B9B9B9",


### PR DESCRIPTION
Hey, you probably don't need another 'minimal' Markdown theme, but I thought I'd put this out there just in case. 

To my mind 'writer' skips a few nice details (like muting syntax) and handles the sidebar strangely (dark blue color + black highlight state). 

FWIW the colours/approach here are from a [slightly-popular](https://github.com/philipbelesky/gray-matter) theme of mine for Sublime/VSCode.