### PR TITLE
Tweak Gray Matter theme's highlights in dark themes

### DIFF
--- a/Themes/Gray Matter (Dark).theme.json
+++ b/Themes/Gray Matter (Dark).theme.json
@@ -8,37 +8,38 @@
             "basedOn": "https://github.com/philipbelesky/gray-matter"
         },
     ],
-    "version": "0.9",
+    "version": "0.10",
     "editor": {
         "backgroundColor": "#1A191A",
         "caretColor": "#29BEEA",
         "selection": {
-            "backgroundColor": "#373737",
-            "unfocusedBackgroundColor": "#d2d9e1"
+            "color": "#FFFFFF",
+            "backgroundColor": "#1C434D",
+            "unfocusedBackgroundColor": "#1C434D",
         },
         "highlight": {
-            "backgroundColor": "#373737",
-            "unfocusedBackgroundColor": "#ececec"
+            "backgroundColor": "#2D2D2D",
+            "unfocusedBackgroundColor": "#2D2D2D"
         }
     },
     "savedSearchesSidebar": {
         "color": "#BEBEBE",
         "backgroundColor": "#222122",
-        "highlightedBackgroundColor": "#373737",
+        "highlightedBackgroundColor": "#1C434D",
         "border": false,
         "iconColors": {
             "default": "#616161"
-        }
+        },
     },
     "resultsList": {
         "color": "#BEBEBE",
         "backgroundColor": "#222122",
         "alternateBackgroundColor": "#1A191A",
         "selection": {
-            "color": "#000",
-            "unfocusedColor": "#000",
-            "backgroundColor": "#373737",
-            "unfocusedBackgroundColor": "#373737"
+            "color": "#FFFFFF",
+            "unfocusedColor": "#FFFFFF",
+            "backgroundColor": "#1C434D",
+            "unfocusedBackgroundColor": "#2D2D2D"
         },
         "border": "#222122",
     },

--- a/Themes/Gray Matter (Light).theme.json
+++ b/Themes/Gray Matter (Light).theme.json
@@ -8,17 +8,18 @@
             "basedOn": "https://github.com/philipbelesky/gray-matter"
         },
     ],
-    "version": "0.9",
+    "version": "0.10",
     "editor": {
         "backgroundColor": "#F5F5F5",
         "caretColor": "#29BEEA",
         "selection": {
+            "color": "#000000",
             "backgroundColor": "#C3E8F3",
-            "unfocusedBackgroundColor": "#d2d9e1"
+            "unfocusedBackgroundColor": "#C3E8F3",
         },
         "highlight": {
-            "backgroundColor": "#C3E8F3",
-            "unfocusedBackgroundColor": "#ececec"
+            "backgroundColor": "#E5E5E5",
+            "unfocusedBackgroundColor": "#E5E5E5"
         }
     },
     "savedSearchesSidebar": {
@@ -28,17 +29,17 @@
         "border": false,
         "iconColors": {
             "default": "#B9B9B9"
-        }
+        },
     },
     "resultsList": {
         "color": "#3C3C3C",
         "backgroundColor": "#EDEDED",
         "alternateBackgroundColor": "#F5F5F5",
         "selection": {
-            "color": "#000",
-            "unfocusedColor": "#000",
+            "color": "#000000",
+            "unfocusedColor": "#000000",
             "backgroundColor": "#C3E8F3",
-            "unfocusedBackgroundColor": "#C3E8F3"
+            "unfocusedBackgroundColor": "#E5E5E5"
         },
         "border": "#EDEDED",
     },


### PR DESCRIPTION
These were a bit too bright and I didn't quite understand the different types of highlights (between omnibar-search, in-text search, text selection)